### PR TITLE
Allow periodic captures

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,6 +16,8 @@ class _MyAppState extends State<MyApp> with TickerProviderStateMixin {
 
   String _captureText = '';
 
+  int _captureCount = 0;
+
   @override
   void initState() {
     super.initState();
@@ -24,6 +26,7 @@ class _MyAppState extends State<MyApp> with TickerProviderStateMixin {
       print('$data');
       setState(() {
         _captureText = data;
+        _captureCount++;
       });
     });
   }
@@ -72,6 +75,10 @@ class _MyAppState extends State<MyApp> with TickerProviderStateMixin {
             ),
             Container(
               child: Text('$_captureText'),
+            ),
+            Container(
+              child: Text('Capture count: $_captureCount'),
+              alignment: Alignment.topCenter.add(Alignment(0, 0.2)),
             )
           ],
         ),


### PR DESCRIPTION
Integrated a feature that allows periodic captures of QR Codes. This is useful for example when the app is reading a QR Code and only needs one call per code read, but the user has his phone pointed out to the QR Code all the time, resulting in multiple unnecessary reads.

GIF's below demonstrate the feature in action:

**With no periodic duration (`durationBetweenCaptures`) set as null**

![Screen Recording 2020-09-16 at 13 23 07 mov](https://user-images.githubusercontent.com/26190214/93336659-f6696b80-f81f-11ea-857a-0f832f518b56.gif)

**With a periodic duration of 2 seconds**

![Screen Recording 2020-09-16 at 13 23 26 mov](https://user-images.githubusercontent.com/26190214/93336668-f9fcf280-f81f-11ea-9a62-f6a9993d828d.gif)