### PR TITLE
Improvement: allow mocking of plugin method channel

### DIFF
--- a/lib/qrcode_flutter.dart
+++ b/lib/qrcode_flutter.dart
@@ -13,7 +13,8 @@ class QRCaptureController {
 
   QRCaptureController();
 
-  void _onPlatformViewCreated(int id) {
+  @visibleForTesting
+  void onPlatformViewCreated(int id) {
     _methodChannel = MethodChannel('plugins/qr_capture/method_$id');
     _methodChannel.setMethodCallHandler((MethodCall call) async {
       if (call.method == 'onCaptured') {
@@ -67,7 +68,7 @@ class QRCaptureViewState extends State<QRCaptureView> {
         viewType: 'plugins/qr_capture_view',
         creationParamsCodec: StandardMessageCodec(),
         onPlatformViewCreated: (id) {
-          widget.controller._onPlatformViewCreated(id);
+          widget.controller.onPlatformViewCreated(id);
         },
       );
     } else {
@@ -75,7 +76,7 @@ class QRCaptureViewState extends State<QRCaptureView> {
         viewType: 'plugins/qr_capture_view',
         creationParamsCodec: StandardMessageCodec(),
         onPlatformViewCreated: (id) {
-          widget.controller._onPlatformViewCreated(id);
+          widget.controller.onPlatformViewCreated(id);
         },
       );
     }


### PR DESCRIPTION
This pull request is an improvement to the existing plugin code. By using the `@visibleForTesting` annotation, the developers can on tests call the `onPlatformViewCreated` method and thus the method channel is created with an id provided on the test, and the `onPlatformViewCreated` method is only visible in the qrcode_flutter.dart file and in test files. This way the plugin calls (resume, pause, capture) can be mocked using the `setMockMethodCall` Flutter API call.